### PR TITLE
chore: ignore Xcode xcuserdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 DerivedData/
 *.xcworkspace
 *.xcuserstate
-*.xcuserdata/
+xcuserdata/
+**/xcuserdata/
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint


### PR DESCRIPTION
## 背景 / 目标

Closes #14

Xcode 会在工程目录下生成 `xcuserdata/`（用户本地状态/断点/设置），不应进入版本控制；目前已在 `git status` 中出现未跟踪文件。

## 主要变更

- 更新 `.gitignore`：忽略 `xcuserdata/` 及其子目录（包括 `.xcodeproj` / `.xcworkspace` 下的用户文件）。

## 测试

- 打开 Xcode / 编译后：`git status --porcelain` 不再出现 `xcuserdata` 相关未跟踪文件。
