### PR TITLE
fix(ci): enforce Xcode project format compatible with CI (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - name: Check Xcode project format (objectVersion)
+        run: scripts/check_xcodeproj_objectversion.sh
       - name: Build macOS app (AIVoiceKeyboard)
         run: xcodebuild -project apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj -scheme AIVoiceKeyboard -configuration Debug -sdk macosx -destination "platform=macOS" build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,11 @@
 - 分支命名与提交规范（Conventional Commits）
 - 用 `gh` CLI 将 plan 文档创建为 Issue 的方式
 
+## Xcode Project Format (CI Compatibility)
+
+CI currently builds the macOS app with Xcode 15.x. If you open/save the
+`AIVoiceKeyboard.xcodeproj` with a newer Xcode, it may upgrade the project file
+format (`objectVersion`) and cause CI to fail with a "future Xcode project file
+format" error.
+
+We enforce this via `scripts/check_xcodeproj_objectversion.sh` (runs in CI).

--- a/scripts/check_xcodeproj_objectversion.sh
+++ b/scripts/check_xcodeproj_objectversion.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fails fast if an Xcode project is saved with a newer "project file format"
+# (objectVersion) than the Xcode version used in CI can understand.
+#
+# Why: GitHub Actions currently builds with Xcode 15.x. If the project is saved
+# with a newer format (e.g. objectVersion 77), CI fails with:
+#   "future Xcode project file format"
+#
+# Usage:
+#   scripts/check_xcodeproj_objectversion.sh [path/to/project.pbxproj]
+#
+# Env:
+#   MAX_OBJECT_VERSION (default: 56)
+
+PBXPROJ_PATH="${1:-apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj/project.pbxproj}"
+MAX_OBJECT_VERSION="${MAX_OBJECT_VERSION:-56}"
+
+if [[ ! -f "$PBXPROJ_PATH" ]]; then
+  echo "ERROR: pbxproj not found: $PBXPROJ_PATH" >&2
+  exit 2
+fi
+
+line="$(grep -E -m1 '^[[:space:]]*objectVersion[[:space:]]*=[[:space:]]*[0-9]+;' "$PBXPROJ_PATH" || true)"
+if [[ -z "$line" ]]; then
+  echo "ERROR: Could not find objectVersion in: $PBXPROJ_PATH" >&2
+  exit 2
+fi
+
+object_version="$(echo "$line" | sed -E 's/.*objectVersion[[:space:]]*=[[:space:]]*([0-9]+);.*/\1/')"
+if [[ -z "$object_version" || ! "$object_version" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: Failed to parse objectVersion from: $line" >&2
+  exit 2
+fi
+
+if (( object_version > MAX_OBJECT_VERSION )); then
+  echo "ERROR: Xcode project format is too new for CI." >&2
+  echo "  pbxproj: $PBXPROJ_PATH" >&2
+  echo "  objectVersion: $object_version (max allowed: $MAX_OBJECT_VERSION)" >&2
+  echo "" >&2
+  echo "Fix options:" >&2
+  echo "  1) Open the project with a CI-compatible Xcode (currently Xcode 15.x) and re-save" >&2
+  echo "  2) If you know the project didn't actually use new features, you may manually set:" >&2
+  echo "     objectVersion = $MAX_OBJECT_VERSION;" >&2
+  exit 1
+fi
+
+echo "OK: objectVersion=$object_version (max allowed: $MAX_OBJECT_VERSION) — $PBXPROJ_PATH"
+


### PR DESCRIPTION
Summary
- 在 CI 中增加 Xcode 工程格式(objectVersion)前置校验，避免 .xcodeproj 被新版本 Xcode 升级后导致 CI 报 "future Xcode project file format"。

Features Implemented
- CI 前置检查：在 macOS app build job 中先校验 `project.pbxproj` 的 `objectVersion` 不高于 CI 支持的上限(默认 56)
- 开发者提示：失败时输出可操作的修复指引（使用 CI 兼容的 Xcode 重新保存/手动回退 objectVersion）
- 文档补充：在 CONTRIBUTING 中说明该约束与原因

Technical Implementation
- New files
  - `scripts/check_xcodeproj_objectversion.sh`: 解析 `objectVersion` 并在版本过新时 fail fast
- Modified files
  - `.github/workflows/ci.yml`: `xcodebuild` 前新增校验 step
  - `CONTRIBUTING.md`: 增加 CI 兼容性说明
- Architecture
  - 将“工程文件格式兼容性”作为 CI 的前置 gate，避免把错误延迟到 xcodebuild 阶段才暴露

Testing
- ✅ `scripts/check_xcodeproj_objectversion.sh`
- ✅ `(cd packages/VoiceKeyboardCore && swift test -c debug)`
- ✅ `xcodebuild -project apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj -scheme AIVoiceKeyboard -configuration Debug -sdk macosx -destination "platform=macOS" build`

Notes
- 当前 CI 以 Xcode 15.x 为基线（max objectVersion=56）。若未来升级 CI 的 Xcode 版本，只需同步调整脚本中的上限。

Fixes #18
