### PR TITLE
feat(stt): add Soniox REST provider (async/file) (#52)

### DIFF
--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj/project.pbxproj
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2D63CD2F8E899CB54F047B80 /* AIVoiceKeyboardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB098512DE92809BDFE721E3 /* AIVoiceKeyboardApp.swift */; };
 		2F5232C7F08262CEB6F71B04 /* RecordingHUDController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F13F940873227C1756DCAC /* RecordingHUDController.swift */; };
 		35FFDE52245FB23955EB69A1 /* OpenAICompatibleSTTEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8CFBF6F3EFAC99E33C20F5 /* OpenAICompatibleSTTEngine.swift */; };
+		F4BAC68058494385A8A006D1 /* SonioxRESTSTTEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFDCCB8671B4C33A353CE36 /* SonioxRESTSTTEngine.swift */; };
 		384F0371693F1A01BE675EDB /* STTSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8A074180E7642DDF3FD07F /* STTSettingsSection.swift */; };
 		425D38A610AEA92E9B9247A8 /* KeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26534F3B81D890FF9C27F9D8 /* KeychainManagerTests.swift */; };
 		457313494E728BA9C7B65E35 /* STTSettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0178E3308878A0B2C2CE2D95 /* STTSettingsModel.swift */; };
@@ -72,6 +73,7 @@
 		202556A7EB1F5BB55614F7B8 /* MockLLMAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLLMAPIClient.swift; sourceTree = "<group>"; };
 		26534F3B81D890FF9C27F9D8 /* KeychainManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManagerTests.swift; sourceTree = "<group>"; };
 		2D8CFBF6F3EFAC99E33C20F5 /* OpenAICompatibleSTTEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAICompatibleSTTEngine.swift; sourceTree = "<group>"; };
+		2EFDCCB8671B4C33A353CE36 /* SonioxRESTSTTEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonioxRESTSTTEngine.swift; sourceTree = "<group>"; };
 		2DD65E212905B6BB33840145 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		32B3D4893DA97C8D2376A548 /* AIVoiceKeyboardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AIVoiceKeyboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		332B2285BAD174EB5D4D1D48 /* TextCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleaner.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 			children = (
 				6141A2C50B788192D5E99F74 /* AppleSpeechSTTEngine.swift */,
 				2D8CFBF6F3EFAC99E33C20F5 /* OpenAICompatibleSTTEngine.swift */,
+				2EFDCCB8671B4C33A353CE36 /* SonioxRESTSTTEngine.swift */,
 				9525CFA467368EA8BE495BA7 /* PushToTalkSTTSession.swift */,
 				7031966727210D33FE0B1309 /* STTEngineFactory.swift */,
 				AAC6761C79980B380DE1010B /* STTProviderStore.swift */,
@@ -386,6 +389,7 @@
 				9F7D49111009120C19DA770C /* LLMRefiner.swift in Sources */,
 				BFAC76DD1754B6849D53860D /* OpenAIClient.swift in Sources */,
 				35FFDE52245FB23955EB69A1 /* OpenAICompatibleSTTEngine.swift in Sources */,
+				F4BAC68058494385A8A006D1 /* SonioxRESTSTTEngine.swift in Sources */,
 				1802C5A303884DB6B7D27C02 /* AXTextInserter.swift in Sources */,
 				ED15A40A3D5DB285D4072A44 /* PasteTextInserter.swift in Sources */,
 				81FADE15F7FE4CE49366FA5F /* SmartTextInserter.swift in Sources */,

--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Permissions/PermissionsGuideView.swift
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Permissions/PermissionsGuideView.swift
@@ -18,6 +18,8 @@ struct PermissionsGuideView: View {
       return NSLocalizedString("stt_provider.whisper_local", comment: "")
     case .openAICompatible:
       return NSLocalizedString("stt_provider.openai_compatible", comment: "")
+    case .sonioxREST:
+      return NSLocalizedString("stt_provider.soniox_rest", comment: "")
     }
   }
 

--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Settings/STTSettingsSection.swift
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Settings/STTSettingsSection.swift
@@ -108,6 +108,61 @@ struct STTSettingsSection: View {
         Text("settings.stt.remote.privacy_hint")
           .font(.footnote)
           .foregroundStyle(.secondary)
+
+      case .sonioxREST:
+        Text("stt_provider.soniox_rest")
+          .font(.headline)
+
+        HStack(spacing: 12) {
+          TextField("settings.stt.remote.base_url_placeholder", text: $model.sonioxBaseURLString)
+          Button("common.action.reset") { model.applyDefaultSonioxBaseURL() }
+        }
+
+        TextField("settings.stt.remote.model_placeholder", text: $model.sonioxModel)
+
+        HStack(spacing: 12) {
+          TextField("settings.stt.remote.api_key_id_placeholder", text: $model.sonioxApiKeyId)
+          Button("common.action.default") { model.sonioxApiKeyId = "soniox" }
+        }
+
+        HStack {
+          Text("common.timeout_seconds")
+          Spacer()
+          TextField("", value: $model.sonioxTimeoutSeconds, formatter: Self.secondsFormatter)
+            .frame(width: 72)
+            .multilineTextAlignment(.trailing)
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+          Text("common.api_key_keychain_title")
+            .font(.headline)
+
+          let statusKey = model.hasSonioxAPIKey ? "common.status.saved" : "common.status.not_saved"
+          let statusLine = String(
+            format: NSLocalizedString("settings.stt.remote.api_key.status_format", comment: ""),
+            NSLocalizedString(statusKey, comment: ""),
+            model.sonioxApiKeyId.trimmingCharacters(in: .whitespacesAndNewlines)
+          )
+          Text(statusLine)
+            .font(.footnote)
+            .foregroundStyle(model.hasSonioxAPIKey ? .green : .secondary)
+
+          HStack(spacing: 12) {
+            SecureField("common.api_key_enter_placeholder", text: $model.apiKeyDraft)
+            Button("common.action.save") { model.saveAPIKey() }
+            Button("common.action.delete") { model.deleteAPIKey() }
+          }
+
+          if let message = model.apiKeyMessage, !message.isEmpty {
+            Text(message)
+              .font(.footnote)
+              .foregroundStyle(model.apiKeyMessageIsError ? .red : .secondary)
+          }
+        }
+
+        Text("settings.stt.remote.privacy_hint")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
       }
 
       if let message = model.configMessage, !message.isEmpty {

--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Speech/STTEngineFactory.swift
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Speech/STTEngineFactory.swift
@@ -32,7 +32,13 @@ enum STTEngineFactory {
         locale: .current,
         stopTimeoutSeconds: max(5.0, cfg.requestTimeoutSeconds + 5.0)
       )
+
+    case .sonioxREST(let cfg):
+      return EngineContext(
+        engine: SonioxRESTSTTEngine(configuration: cfg),
+        locale: .current,
+        stopTimeoutSeconds: max(5.0, cfg.requestTimeoutSeconds + 5.0)
+      )
     }
   }
 }
-

--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Speech/SonioxRESTSTTEngine.swift
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Speech/SonioxRESTSTTEngine.swift
@@ -1,0 +1,372 @@
+import AVFoundation
+import Foundation
+import VoiceKeyboardCore
+
+actor SonioxRESTSTTEngine: STTEngine {
+  enum EngineError: LocalizedError {
+    case alreadyRunning
+    case recorderFailed
+    case apiKeyMissing(apiKeyId: String)
+    case httpError(statusCode: Int, body: String)
+    case invalidResponse
+    case transcriptionFailed(message: String?)
+    case timedOut(seconds: Double)
+    case noResult
+
+    var errorDescription: String? {
+      switch self {
+      case .alreadyRunning:
+        return "STT session already running"
+      case .recorderFailed:
+        return "Failed to start audio recording"
+      case .apiKeyMissing(let apiKeyId):
+        return "Missing Soniox API key for id: \(apiKeyId). Configure it in Settings."
+      case .httpError(let statusCode, let body):
+        if body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          return "Soniox request failed (HTTP \(statusCode))"
+        }
+        return "Soniox request failed (HTTP \(statusCode)): \(body)"
+      case .invalidResponse:
+        return "Invalid Soniox response"
+      case .transcriptionFailed(let message):
+        if let message, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          return "Soniox transcription failed: \(message)"
+        }
+        return "Soniox transcription failed"
+      case .timedOut(let seconds):
+        return "Soniox transcription timed out after \(Int(seconds))s."
+      case .noResult:
+        return "No transcription result"
+      }
+    }
+  }
+
+  nonisolated let id: String = "soniox_rest"
+  nonisolated let displayName: String = "Soniox (REST)"
+
+  private let configuration: SonioxRESTSTTConfiguration
+
+  private var recorder: AVAudioRecorder?
+  private var sessionDir: URL?
+  private var recordingURL: URL?
+  private var continuation: AsyncThrowingStream<Transcript, Error>.Continuation?
+  private var isStopping: Bool = false
+
+  init(configuration: SonioxRESTSTTConfiguration) {
+    self.configuration = configuration
+  }
+
+  func capabilities() async -> STTCapabilities {
+    STTCapabilities(
+      supportsStreaming: false,
+      supportsOnDeviceRecognition: false,
+      supportedLocaleIdentifiers: nil
+    )
+  }
+
+  func streamTranscripts(locale: Locale) async throws -> STTTranscriptStream {
+    guard recorder == nil, continuation == nil, !isStopping else { throw EngineError.alreadyRunning }
+
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("avkb-stt-soniox-rest-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+    let recordingURL = dir.appendingPathComponent("recording.wav", isDirectory: false)
+
+    // Soniox auto-detects WAV; use a simple 16kHz mono PCM WAV to reduce format ambiguity.
+    let settings: [String: Any] = [
+      AVFormatIDKey: kAudioFormatLinearPCM,
+      AVSampleRateKey: 16_000,
+      AVNumberOfChannelsKey: 1,
+      AVLinearPCMBitDepthKey: 16,
+      AVLinearPCMIsFloatKey: false,
+      AVLinearPCMIsBigEndianKey: false
+    ]
+
+    let recorder = try AVAudioRecorder(url: recordingURL, settings: settings)
+    recorder.prepareToRecord()
+    guard recorder.record() else { throw EngineError.recorderFailed }
+
+    self.sessionDir = dir
+    self.recordingURL = recordingURL
+    self.recorder = recorder
+
+    return STTTranscriptStream(
+      makeStream: { continuation in
+        Task { await self.bindContinuation(continuation) }
+      },
+      cancel: {
+        await self.stopAndTranscribe(locale: locale)
+      }
+    )
+  }
+
+  private func bindContinuation(_ continuation: AsyncThrowingStream<Transcript, Error>.Continuation) {
+    self.continuation = continuation
+  }
+
+  private func stopAndTranscribe(locale: Locale) async {
+    guard !isStopping else { return }
+    isStopping = true
+
+    let cont = continuation
+    continuation = nil
+
+    let dir = sessionDir
+    let audioURL = recordingURL
+
+    recorder?.stop()
+    recorder = nil
+
+    defer {
+      if let dir {
+        try? FileManager.default.removeItem(at: dir)
+      }
+      sessionDir = nil
+      recordingURL = nil
+      isStopping = false
+    }
+
+    guard let cont else { return }
+    guard let audioURL else {
+      cont.finish(throwing: EngineError.noResult)
+      return
+    }
+
+    do {
+      let text = try await transcribe(audioURL: audioURL, locale: locale)
+      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else {
+        cont.finish(throwing: EngineError.noResult)
+        return
+      }
+      cont.yield(Transcript(text: text, isFinal: true))
+      cont.finish()
+    } catch {
+      cont.finish(throwing: error)
+    }
+  }
+
+  private func transcribe(audioURL: URL, locale: Locale) async throws -> String {
+    let apiKeyId = configuration.apiKeyId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let apiKey = try STTKeychain.load(apiKeyId: apiKeyId),
+          !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw EngineError.apiKeyMissing(apiKeyId: apiKeyId)
+    }
+
+    let fileId = try await uploadFile(audioURL: audioURL, apiKey: apiKey)
+    let transcriptionId = try await createTranscription(fileId: fileId, locale: locale, apiKey: apiKey)
+    try await waitForTranscription(transcriptionId: transcriptionId, apiKey: apiKey)
+    return try await fetchTranscript(transcriptionId: transcriptionId, apiKey: apiKey)
+  }
+
+  private func apiBaseURL() -> URL {
+    // Allow either https://api.soniox.com or https://api.soniox.com/v1 in settings.
+    let base = configuration.baseURL
+    if base.pathComponents.last == "v1" {
+      return base
+    }
+    return base.appendingPathComponent("v1")
+  }
+
+  private func uploadFile(audioURL: URL, apiKey: String) async throws -> String {
+    struct UploadedFile: Decodable { var id: String }
+
+    let boundary = "Boundary-\(UUID().uuidString)"
+    let bodyURL = (sessionDir ?? FileManager.default.temporaryDirectory)
+      .appendingPathComponent("soniox-upload-body.bin", isDirectory: false)
+
+    try MultipartWriter.write(
+      to: bodyURL,
+      boundary: boundary,
+      fields: [("client_reference_id", "avkb-\(UUID().uuidString)")],
+      fileFieldName: "file",
+      fileURL: audioURL,
+      filename: "recording.wav",
+      mimeType: "audio/wav"
+    )
+    defer { try? FileManager.default.removeItem(at: bodyURL) }
+
+    let endpoint = apiBaseURL().appendingPathComponent("files")
+    var request = URLRequest(url: endpoint)
+    request.httpMethod = "POST"
+    request.timeoutInterval = configuration.requestTimeoutSeconds
+    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+    let (data, response) = try await URLSession.shared.upload(for: request, fromFile: bodyURL)
+    guard let http = response as? HTTPURLResponse else { throw EngineError.invalidResponse }
+    guard (200..<300).contains(http.statusCode) else {
+      let body = String(data: data, encoding: .utf8) ?? ""
+      throw EngineError.httpError(statusCode: http.statusCode, body: body)
+    }
+
+    let decoded = try JSONDecoder().decode(UploadedFile.self, from: data)
+    return decoded.id
+  }
+
+  private func createTranscription(fileId: String, locale: Locale, apiKey: String) async throws -> String {
+    struct Payload: Encodable {
+      var model: String
+      var fileId: String
+      var languageHints: [String]?
+
+      enum CodingKeys: String, CodingKey {
+        case model
+        case fileId = "file_id"
+        case languageHints = "language_hints"
+      }
+    }
+
+    struct Created: Decodable { var id: String }
+
+    let model = configuration.model.trimmingCharacters(in: .whitespacesAndNewlines)
+    let lang = locale.language.languageCode?.identifier
+    let hints = (lang?.isEmpty == false) ? [lang!] : nil
+
+    let payload = Payload(model: model, fileId: fileId, languageHints: hints)
+    let data = try JSONEncoder().encode(payload)
+
+    let endpoint = apiBaseURL().appendingPathComponent("transcriptions")
+    var request = URLRequest(url: endpoint)
+    request.httpMethod = "POST"
+    request.timeoutInterval = configuration.requestTimeoutSeconds
+    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+    let (respData, response) = try await URLSession.shared.upload(for: request, from: data)
+    guard let http = response as? HTTPURLResponse else { throw EngineError.invalidResponse }
+    guard (200..<300).contains(http.statusCode) else {
+      let body = String(data: respData, encoding: .utf8) ?? ""
+      throw EngineError.httpError(statusCode: http.statusCode, body: body)
+    }
+
+    let decoded = try JSONDecoder().decode(Created.self, from: respData)
+    return decoded.id
+  }
+
+  private func waitForTranscription(transcriptionId: String, apiKey: String) async throws {
+    struct StatusResponse: Decodable {
+      var status: String
+      var errorMessage: String?
+
+      enum CodingKeys: String, CodingKey {
+        case status
+        case errorMessage = "error_message"
+      }
+    }
+
+    let deadline = Date().addingTimeInterval(configuration.requestTimeoutSeconds)
+    let endpoint = apiBaseURL().appendingPathComponent("transcriptions").appendingPathComponent(transcriptionId)
+
+    while true {
+      if Date() > deadline {
+        throw EngineError.timedOut(seconds: configuration.requestTimeoutSeconds)
+      }
+
+      var request = URLRequest(url: endpoint)
+      request.httpMethod = "GET"
+      request.timeoutInterval = configuration.requestTimeoutSeconds
+      request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+      let (data, response) = try await URLSession.shared.data(for: request)
+      guard let http = response as? HTTPURLResponse else { throw EngineError.invalidResponse }
+      guard (200..<300).contains(http.statusCode) else {
+        let body = String(data: data, encoding: .utf8) ?? ""
+        throw EngineError.httpError(statusCode: http.statusCode, body: body)
+      }
+
+      let decoded = try JSONDecoder().decode(StatusResponse.self, from: data)
+      switch decoded.status {
+      case "completed":
+        return
+      case "error":
+        throw EngineError.transcriptionFailed(message: decoded.errorMessage)
+      default:
+        // queued / processing
+        try? await Task.sleep(nanoseconds: 500_000_000)
+      }
+    }
+  }
+
+  private func fetchTranscript(transcriptionId: String, apiKey: String) async throws -> String {
+    struct TranscriptResponse: Decodable { var text: String }
+
+    let endpoint = apiBaseURL()
+      .appendingPathComponent("transcriptions")
+      .appendingPathComponent(transcriptionId)
+      .appendingPathComponent("transcript")
+
+    var request = URLRequest(url: endpoint)
+    request.httpMethod = "GET"
+    request.timeoutInterval = configuration.requestTimeoutSeconds
+    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard let http = response as? HTTPURLResponse else { throw EngineError.invalidResponse }
+    guard (200..<300).contains(http.statusCode) else {
+      let body = String(data: data, encoding: .utf8) ?? ""
+      throw EngineError.httpError(statusCode: http.statusCode, body: body)
+    }
+
+    let decoded = try JSONDecoder().decode(TranscriptResponse.self, from: data)
+    return decoded.text
+  }
+
+  private enum MultipartWriter {
+    static func write(
+      to url: URL,
+      boundary: String,
+      fields: [(String, String)],
+      fileFieldName: String,
+      fileURL: URL,
+      filename: String,
+      mimeType: String
+    ) throws {
+      FileManager.default.createFile(atPath: url.path, contents: nil)
+      let handle = try FileHandle(forWritingTo: url)
+      defer { try? handle.close() }
+
+      func writeString(_ s: String) throws {
+        if let data = s.data(using: .utf8) {
+          try handle.write(contentsOf: data)
+        }
+      }
+
+      func sanitizeDispositionValue(_ s: String) -> String {
+        var out = s
+        out = out.replacingOccurrences(of: "\r", with: "")
+        out = out.replacingOccurrences(of: "\n", with: "")
+        out = out.replacingOccurrences(of: "\"", with: "'")
+        return out
+      }
+
+      for (name, value) in fields {
+        let safeName = sanitizeDispositionValue(name)
+        try writeString("--\(boundary)\r\n")
+        try writeString("Content-Disposition: form-data; name=\"\(safeName)\"\r\n\r\n")
+        try writeString(value)
+        try writeString("\r\n")
+      }
+
+      let safeFileFieldName = sanitizeDispositionValue(fileFieldName)
+      let safeFilename = sanitizeDispositionValue(filename)
+      try writeString("--\(boundary)\r\n")
+      try writeString("Content-Disposition: form-data; name=\"\(safeFileFieldName)\"; filename=\"\(safeFilename)\"\r\n")
+      try writeString("Content-Type: \(mimeType)\r\n\r\n")
+
+      let readHandle = try FileHandle(forReadingFrom: fileURL)
+      defer { try? readHandle.close() }
+
+      while true {
+        let chunk = try readHandle.read(upToCount: 64 * 1024) ?? Data()
+        if chunk.isEmpty { break }
+        try handle.write(contentsOf: chunk)
+      }
+
+      try writeString("\r\n")
+      try writeString("--\(boundary)--\r\n")
+    }
+  }
+}
+

--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/en.lproj/Localizable.strings
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/en.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "stt_provider.apple_speech" = "Apple Speech";
 "stt_provider.whisper_local" = "Whisper (Local)";
 "stt_provider.openai_compatible" = "Remote (OpenAI-compatible)";
+"stt_provider.soniox_rest" = "Soniox (REST)";
 
 /* Permission kinds */
 "permission.kind.microphone" = "Microphone";

--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/zh-Hans.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "stt_provider.apple_speech" = "Apple Speech";
 "stt_provider.whisper_local" = "Whisper（本地）";
 "stt_provider.openai_compatible" = "远端（OpenAI 兼容）";
+"stt_provider.soniox_rest" = "Soniox（REST）";
 
 /* Permission kinds */
 "permission.kind.microphone" = "麦克风";

--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/zh-Hant.lproj/Localizable.strings
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/zh-Hant.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "stt_provider.apple_speech" = "Apple Speech";
 "stt_provider.whisper_local" = "Whisper（本機）";
 "stt_provider.openai_compatible" = "遠端（OpenAI 相容）";
+"stt_provider.soniox_rest" = "Soniox（REST）";
 
 /* Permission kinds */
 "permission.kind.microphone" = "麥克風";

--- a/packages/VoiceKeyboardCore/Sources/VoiceKeyboardCore/Config/ConfigurationValidation.swift
+++ b/packages/VoiceKeyboardCore/Sources/VoiceKeyboardCore/Config/ConfigurationValidation.swift
@@ -79,6 +79,17 @@ public extension OpenAICompatibleSTTConfiguration {
   }
 }
 
+public extension SonioxRESTSTTConfiguration {
+  func validate() -> [ConfigurationValidationIssue] {
+    var issues: [ConfigurationValidationIssue] = []
+    issues += ConfigurationValidation.validateBaseURL(baseURL, field: "baseURL")
+    issues += ConfigurationValidation.validateNonEmpty(apiKeyId, field: "apiKeyId")
+    issues += ConfigurationValidation.validateNonEmpty(model, field: "model")
+    issues += ConfigurationValidation.validateTimeout(requestTimeoutSeconds, field: "requestTimeoutSeconds")
+    return issues
+  }
+}
+
 public extension WhisperLocalConfiguration {
   func validate() -> [ConfigurationValidationIssue] {
     var issues: [ConfigurationValidationIssue] = []
@@ -111,6 +122,8 @@ public extension STTProviderConfiguration {
     case .whisperLocal(let cfg):
       return cfg.validate()
     case .openAICompatible(let cfg):
+      return cfg.validate()
+    case .sonioxREST(let cfg):
       return cfg.validate()
     }
   }

--- a/packages/VoiceKeyboardCore/Sources/VoiceKeyboardCore/Config/ProviderConfigurations.swift
+++ b/packages/VoiceKeyboardCore/Sources/VoiceKeyboardCore/Config/ProviderConfigurations.swift
@@ -69,6 +69,20 @@ public struct OpenAICompatibleSTTConfiguration: Codable, Equatable, Sendable {
   }
 }
 
+public struct SonioxRESTSTTConfiguration: Codable, Equatable, Sendable {
+  public var baseURL: URL
+  public var apiKeyId: String
+  public var model: String
+  public var requestTimeoutSeconds: Double
+
+  public init(baseURL: URL, apiKeyId: String, model: String, requestTimeoutSeconds: Double) {
+    self.baseURL = baseURL
+    self.apiKeyId = apiKeyId
+    self.model = model
+    self.requestTimeoutSeconds = requestTimeoutSeconds
+  }
+}
+
 public struct WhisperLocalConfiguration: Codable, Equatable, Sendable {
   /// Optional absolute path to the `whisper` executable.
   ///
@@ -103,6 +117,7 @@ public enum STTProviderConfiguration: Codable, Equatable, Sendable {
   case appleSpeech(AppleSpeechConfiguration)
   case whisperLocal(WhisperLocalConfiguration)
   case openAICompatible(OpenAICompatibleSTTConfiguration)
+  case sonioxREST(SonioxRESTSTTConfiguration)
 
   private enum CodingKeys: String, CodingKey {
     case type
@@ -121,6 +136,9 @@ public enum STTProviderConfiguration: Codable, Equatable, Sendable {
     case .openAICompatible(let cfg):
       try container.encode("openai_compatible", forKey: .type)
       try container.encode(cfg, forKey: .config)
+    case .sonioxREST(let cfg):
+      try container.encode("soniox_rest", forKey: .type)
+      try container.encode(cfg, forKey: .config)
     }
   }
 
@@ -134,6 +152,8 @@ public enum STTProviderConfiguration: Codable, Equatable, Sendable {
       self = .whisperLocal(try container.decode(WhisperLocalConfiguration.self, forKey: .config))
     case "openai_compatible":
       self = .openAICompatible(try container.decode(OpenAICompatibleSTTConfiguration.self, forKey: .config))
+    case "soniox_rest":
+      self = .sonioxREST(try container.decode(SonioxRESTSTTConfiguration.self, forKey: .config))
     default:
       throw DecodingError.dataCorruptedError(
         forKey: .type,

--- a/packages/VoiceKeyboardCore/Tests/VoiceKeyboardCoreTests/ConfigurationValidationTests.swift
+++ b/packages/VoiceKeyboardCore/Tests/VoiceKeyboardCoreTests/ConfigurationValidationTests.swift
@@ -28,6 +28,19 @@ final class ConfigurationValidationTests: XCTestCase {
     XCTAssertTrue(issues.contains { $0.field == "model" && $0.severity == .error })
   }
 
+  func testValidateSonioxRESTConfigurationRejectsEmptyApiKeyIdAndModel() throws {
+    let cfg = SonioxRESTSTTConfiguration(
+      baseURL: URL(string: "https://api.soniox.com")!,
+      apiKeyId: "   ",
+      model: "",
+      requestTimeoutSeconds: 10
+    )
+
+    let issues = cfg.validate()
+    XCTAssertTrue(issues.contains { $0.field == "apiKeyId" && $0.severity == .error })
+    XCTAssertTrue(issues.contains { $0.field == "model" && $0.severity == .error })
+  }
+
   func testValidateBaseURLHttpIsWarning() throws {
     let cfg = OpenAICompatibleLLMConfiguration(
       baseURL: URL(string: "http://example.com")!,

--- a/packages/VoiceKeyboardCore/Tests/VoiceKeyboardCoreTests/ProviderConfigurationCodableTests.swift
+++ b/packages/VoiceKeyboardCore/Tests/VoiceKeyboardCoreTests/ProviderConfigurationCodableTests.swift
@@ -33,6 +33,21 @@ final class ProviderConfigurationCodableTests: XCTestCase {
     XCTAssertEqual(decoded, cfg)
   }
 
+  func testSonioxRESTSTTProviderConfigurationCodableRoundTrip() throws {
+    let cfg = STTProviderConfiguration.sonioxREST(
+      SonioxRESTSTTConfiguration(
+        baseURL: URL(string: "https://api.soniox.com")!,
+        apiKeyId: "key_soniox",
+        model: "stt-async-preview",
+        requestTimeoutSeconds: 45
+      )
+    )
+
+    let data = try JSONEncoder().encode(cfg)
+    let decoded = try JSONDecoder().decode(STTProviderConfiguration.self, from: data)
+    XCTAssertEqual(decoded, cfg)
+  }
+
   func testWhisperLocalSTTProviderConfigurationCodableRoundTrip() throws {
     let cfg = STTProviderConfiguration.whisperLocal(
       WhisperLocalConfiguration(


### PR DESCRIPTION
**Summary**
Add Soniox REST (async/file) as a new STT provider option (Core config + validation, macOS Settings wiring, and a REST engine implementation). Fixes #52.

**Features Implemented**
- Soniox REST STT provider config: baseURL / model / apiKeyId / timeout (API key stored in Keychain)
- SonioxRESTSTTEngine: record WAV (16kHz mono PCM) -> upload `/v1/files` -> create `/v1/transcriptions` -> poll status -> fetch transcript
- VoiceKeyboardCore: new `SonioxRESTSTTConfiguration` + `STTProviderConfiguration.sonioxREST`, with validation + Codable round-trip tests

**Technical Implementation**
- 新增文件
  - `apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Speech/SonioxRESTSTTEngine.swift`
- 修改文件
  - `apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Speech/STTEngineFactory.swift`
  - `apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Settings/STTSettingsModel.swift`
  - `apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Settings/STTSettingsSection.swift`
  - `apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/Permissions/PermissionsGuideView.swift`
  - `packages/VoiceKeyboardCore/Sources/VoiceKeyboardCore/Config/ProviderConfigurations.swift`
  - `packages/VoiceKeyboardCore/Sources/VoiceKeyboardCore/Config/ConfigurationValidation.swift`
  - `packages/VoiceKeyboardCore/Tests/VoiceKeyboardCoreTests/ProviderConfigurationCodableTests.swift`
  - `packages/VoiceKeyboardCore/Tests/VoiceKeyboardCoreTests/ConfigurationValidationTests.swift`
  - `apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/en.lproj/Localizable.strings`
  - `apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/zh-Hans.lproj/Localizable.strings`
  - `apps/macos/AIVoiceKeyboard/AIVoiceKeyboard/zh-Hant.lproj/Localizable.strings`
- 架构设计
  - 延续现有 `STTProviderConfiguration` + `STTEngineFactory` + `STTEngine` 分层：Core 负责配置与校验；macOS target 提供具体 engine；Settings 负责落地配置与 Keychain 管理。

**Performance Considerations**
- Poll interval: 500ms to avoid overly frequent requests.
- Record as WAV to reduce format ambiguity for Soniox uploads (tradeoff: larger files, acceptable for push-to-talk durations).

**Testing**
- ✅ `swift test -c debug` (packages/VoiceKeyboardCore)
- ✅ `xcodebuild -project apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj -scheme AIVoiceKeyboard -configuration Debug -sdk macosx -destination "platform=macOS" build`
- ✅ `xcodebuild -project apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj -scheme AIVoiceKeyboard -configuration Debug -sdk macosx -destination "platform=macOS" test`

**Screenshots/Notes**
- Settings: new `Soniox (REST)` provider; baseURL accepts `https://api.soniox.com` or `https://api.soniox.com/v1`.
- WebSocket realtime STT is tracked separately and intentionally out of scope for this PR.
