### PR TITLE
fix(macos): ad-hoc sign app bundle to persist mic + keychain permissions

### DIFF
--- a/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj/project.pbxproj
+++ b/apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj/project.pbxproj
@@ -511,7 +511,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_ALLOWED = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = AIVoiceKeyboard/Info.plist;
@@ -529,7 +531,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_ALLOWED = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = AIVoiceKeyboard/Info.plist;

--- a/apps/macos/AIVoiceKeyboard/project.yml
+++ b/apps/macos/AIVoiceKeyboard/project.yml
@@ -23,7 +23,12 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: 0.1.0
         INFOPLIST_FILE: AIVoiceKeyboard/Info.plist
-        CODE_SIGNING_ALLOWED: NO
+        # Ad-hoc sign by default so macOS can persist TCC (microphone/speech) + Keychain
+        # permissions for DMG builds. Can be overridden in release pipelines with a
+        # real Developer ID identity + notarization.
+        CODE_SIGNING_ALLOWED: YES
+        CODE_SIGN_STYLE: Manual
+        CODE_SIGN_IDENTITY: "-"
     dependencies:
       - package: VoiceKeyboardCore
   


### PR DESCRIPTION
**Summary**
Enable ad-hoc signing ("Sign to Run Locally") for the macOS app target so DMG builds have a stable code requirement, allowing macOS to persist TCC (Microphone/Speech) and Keychain access decisions.

**Why**
Unsigned app bundles can cause repeated permission prompts (mic) and repeated Keychain authorization dialogs in DMG-distributed builds, even after the user clicks Allow.

**Technical Implementation**
- Update Xcode build settings to allow ad-hoc signing via `CODE_SIGNING_ALLOWED=YES`, `CODE_SIGN_STYLE=Manual`, `CODE_SIGN_IDENTITY="-"`.
- Keep this as the default; release pipelines can override with Developer ID signing + notarization as needed.

**Testing**
- ✅ `swift test -c debug` (packages/VoiceKeyboardCore)
- ✅ `xcodebuild -project apps/macos/AIVoiceKeyboard/AIVoiceKeyboard.xcodeproj -scheme AIVoiceKeyboard -configuration Debug -sdk macosx -destination "platform=macOS" build`

**Notes**
- After this change, macOS may ask once again for mic/keychain on first run of the newly-signed build (expected), then persist normally.
